### PR TITLE
Fixes error when doing `mix ecto.create`

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -14,6 +14,8 @@ config :ex_admin_demo, ExAdminDemo.Endpoint,
   pubsub: [name: ExAdminDemo.PubSub,
            adapter: Phoenix.PubSub.PG2]
 
+config :ex_admin_demo, ecto_repos: [ExAdminDemo.Repo]
+
 # Configures Elixir's Logger
 config :logger, :console,
   format: "$time $metadata[$level] $message\n",


### PR DESCRIPTION
When creating database in freshly checked out project, following error
is generated.

$ mix ecto.create

warning: could not find repositories for application
:ex_admin_demo.

You can avoid this warning by passing the -r
flag or by setting the
repositories managed by this application in
your config/config.exs:

config :ex_admin_demo, ecto_repos:
[...]

The configuration may be an
empty list if it does not
define any
repo.